### PR TITLE
feat: Integrate dynamic venue data for map display

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -44,24 +44,61 @@ BEGIN
 END
 $$;
 
--- Venues Table (Placeholder for future, if using SQL for venues)
-/*
+-- Venues Table
+-- Stores information about pet-friendly businesses and locations.
+-- Inspired by the user-provided 'businesses' table from MariaDB dump.
 CREATE TABLE IF NOT EXISTS venues (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id UUID REFERENCES users(id) ON DELETE SET NULL, -- Optional: link to the user who owns/manages this venue
     name VARCHAR(255) NOT NULL,
-    address TEXT,
-    latitude DOUBLE PRECISION NOT NULL,
-    longitude DOUBLE PRECISION NOT NULL,
-    type VARCHAR(100), -- e.g., 'cafe', 'park', 'store'
+    address TEXT, -- Full address as a single text block for simplicity now
+    city VARCHAR(100),
+    state_province VARCHAR(100),
+    postal_code VARCHAR(20),
+    country VARCHAR(100),
+    latitude DECIMAL(10,8) NOT NULL, -- Sufficient precision for Leaflet
+    longitude DECIMAL(11,8) NOT NULL, -- Sufficient precision for Leaflet
+    phone_number VARCHAR(30),
+    website VARCHAR(255),
     description TEXT,
-    created_by UUID REFERENCES users(id), -- Optional: link to user who added it
+    opening_hours JSONB, -- Store opening hours as JSON (e.g., { "Mon": "9am-5pm", "Tue": ... })
+
+    type VARCHAR(50) NOT NULL DEFAULT 'unknown', -- e.g., 'cafe', 'park', 'store', 'restaurant', 'hotel'
+
+    -- Pet Policy Fields (simplified from user's schema)
+    pet_policy_summary VARCHAR(255),
+    pet_policy_details TEXT,
+    allows_off_leash BOOLEAN DEFAULT FALSE,
+    has_indoor_seating_for_pets BOOLEAN DEFAULT FALSE,
+    has_outdoor_seating_for_pets BOOLEAN DEFAULT FALSE,
+    water_bowls_provided BOOLEAN DEFAULT FALSE,
+    pet_treats_available BOOLEAN DEFAULT FALSE,
+    pet_menu_available BOOLEAN DEFAULT FALSE,
+    dedicated_pet_area BOOLEAN DEFAULT FALSE,
+    weight_limit_kg DECIMAL(5,2),
+    -- pet_size_limit VARCHAR(20) CHECK (pet_size_limit IN ('small', 'medium', 'large', 'any')) DEFAULT 'any', -- Using VARCHAR instead of ENUM for broader compatibility
+    carrier_required BOOLEAN DEFAULT FALSE,
+    additional_pet_services TEXT,
+
+    -- Rating & Status (simplified)
+    -- average_rating DECIMAL(3,2) DEFAULT 0.00, -- Could be calculated or from a reviews table
+    -- review_count INT DEFAULT 0,
+    status VARCHAR(50) DEFAULT 'active', -- e.g., 'active', 'pending_approval', 'temporarily_closed'
+
+    google_place_id VARCHAR(255) UNIQUE, -- Optional: for linking with Google Places
+
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Indexes for common query fields
+CREATE INDEX IF NOT EXISTS idx_venues_name ON venues(name); -- For searching by name (consider GIN/GIST for full-text search later)
 CREATE INDEX IF NOT EXISTS idx_venues_type ON venues(type);
-CREATE INDEX IF NOT EXISTS idx_venues_location ON venues USING GIST (ll_to_earth(latitude, longitude)); -- Requires earthdistance extension
+CREATE INDEX IF NOT EXISTS idx_venues_city ON venues(city);
+-- For geospatial queries, PostGIS extension would be ideal. For now, simple lat/long.
+-- CREATE INDEX IF NOT EXISTS idx_venues_location ON venues USING GIST (ll_to_earth(latitude, longitude)); -- Requires earthdistance & cube extensions
 
+-- Apply the updated_at trigger to venues table
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -76,17 +113,55 @@ BEGIN
   END IF;
 END
 $$;
-*/
 
--- Add more tables as needed (Pets, Reviews, etc.)
+
+-- Add more tables as needed (Pets, Reviews, Images, Favorites, Awards etc. from user's schema)
 
 -- Initial data (optional examples)
 /*
 -- Example: Inserting a test user (password is 'password123' hashed)
 -- You'd normally do this via your application's registration
-INSERT INTO users (email, name, password_hash) VALUES
-('testuser@example.com', 'Test User', '$2a$10$xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
--- Replace with an actual bcrypt hash if testing manually
+-- Ensure you have a valid password_hash if inserting manually.
+-- Example: INSERT INTO users (email, name, password_hash) VALUES
+-- ('owner@example.com', 'Venue Owner', '$2a$10$somebcryptgeneratedhashhere');
+
+-- Sample Venue Data (uncomment and modify as needed)
+-- Make sure to replace 'owner_user_id_placeholder' with an actual user's UUID if you have one, or set to NULL.
+
+/*
+INSERT INTO venues (
+    name, address, city, state_province, postal_code, country,
+    latitude, longitude, phone_number, website, description, opening_hours, type,
+    pet_policy_summary, allows_off_leash, has_outdoor_seating_for_pets, water_bowls_provided, status
+) VALUES
+(
+    'The Wagging Tail Cafe', '123 Bark Street', 'Pawsburg', 'CA', '90210', 'USA',
+    34.052235, -118.243683, '555-1234', 'http://waggingtail.com',
+    'A friendly cafe that loves dogs! We have a special patio area for pets and offer free puppuccinos.',
+    '{ "Mon-Fri": "8am-6pm", "Sat": "9am-4pm", "Sun": "Closed" }'::jsonb, 'cafe',
+    'Well-behaved dogs welcome on the patio. Water bowls available.', TRUE, TRUE, TRUE, 'active'
+),
+(
+    'Happy Hounds Park', '456 Fetch Lane', 'Pawsburg', 'CA', '90211', 'USA',
+    34.062235, -118.253683, NULL, NULL,
+    'Large, fenced-in off-leash dog park with separate areas for small and large dogs. Features agility equipment and water fountains.',
+    '{ "Mon-Sun": "6am-10pm" }'::jsonb, 'park',
+    'Dogs must be vaccinated and licensed. Owners must clean up after their pets.', TRUE, TRUE, TRUE, 'active'
+),
+(
+    'The Pampered Pet Store', '789 Treat Boulevard', 'Pawsburg', 'CA', '90212', 'USA',
+    34.072235, -118.263683, '555-5678', 'http://pamperedpet.com',
+    'Your one-stop shop for premium pet food, toys, accessories, and grooming services. Leashed pets are welcome inside!',
+    '{ "Mon-Sat": "9am-8pm", "Sun": "10am-6pm" }'::jsonb, 'store',
+    'Leashed, well-behaved pets are welcome in the store.', FALSE, TRUE, FALSE, 'active'
+),
+(
+    'Seaside Dog Beach', 'Beach Road End', 'Pawsburg', 'CA', '90213', 'USA',
+    34.042235, -118.233683, NULL, NULL,
+    'Designated off-leash dog beach area. Enjoy the sun, sand, and surf with your furry friend!',
+    '{ "Mon-Sun": "Dawn till Dusk" }'::jsonb, 'park', -- 'beach' could also be a type
+    'Off-leash allowed in designated area. Please observe all beach rules.', TRUE, TRUE, FALSE, 'active'
+);
 */
 
 SELECT 'Schema setup complete.' AS status;

--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -32,18 +32,45 @@ type Mutation {
 #   owner: User!
 # }
 
+scalar JSON # For opening_hours
+
 type Venue {
   id: ID!
+  owner_user_id: ID # Corresponds to UUID of user
   name: String!
-  address: String # Simplified for now, could be more structured
+  address: String
+  city: String
+  state_province: String
+  postal_code: String
+  country: String
   latitude: Float!
   longitude: Float!
-  type: String # e.g., "cafe", "park", "store"
+  phone_number: String
+  website: String
   description: String
-  # Add more fields as per README's VenueData, e.g.:
-  # hyperDetailedPolicies: PolicyMatrix
-  # realTimeAvailability: LiveStatus
-  # pawStarRating: CommunityVerification
+  opening_hours: JSON # Use the scalar JSON type
+  type: String! # e.g., "cafe", "park", "store"
+
+  pet_policy_summary: String
+  pet_policy_details: String
+  allows_off_leash: Boolean
+  has_indoor_seating_for_pets: Boolean
+  has_outdoor_seating_for_pets: Boolean
+  water_bowls_provided: Boolean
+  pet_treats_available: Boolean
+  pet_menu_available: Boolean
+  dedicated_pet_area: Boolean
+  weight_limit_kg: Float
+  carrier_required: Boolean
+  additional_pet_services: String
+
+  status: String # e.g., 'active', 'pending_approval'
+  google_place_id: String
+
+  created_at: String # Typically represented as ISO8601 String
+  updated_at: String # Typically represented as ISO8601 String
+
+  # Future computed fields can be added here, e.g., averageRating
 }
 
 # Input type for filtering venues (optional for Phase 1 simple filter)

--- a/web/src/app/map/page.tsx
+++ b/web/src/app/map/page.tsx
@@ -1,84 +1,139 @@
-'use client'; // This page now uses client-side components and state (soon)
+'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { gql, useQuery } from '@apollo/client';
 import MapDisplay from '@/components/MapDisplay'; // Import the dynamically loaded map
 
-// Placeholder for Venue data structure, will come from GraphQL later
+// Define the GraphQL query for searching venues
+const SEARCH_VENUES_QUERY = gql`
+  query SearchVenues($filterByName: String, $filterByType: String) {
+    searchVenues(filterByName: $filterByName, filterByType: $filterByType) {
+      id
+      name
+      address
+      city
+      latitude
+      longitude
+      type
+      description
+      pet_policy_summary
+      allows_off_leash
+      has_outdoor_seating_for_pets
+      water_bowls_provided
+      opening_hours # This is JSON, ensure MapDisplayCore can handle or format it
+    }
+  }
+`;
+
+// Match the Venue type expected by MapDisplay and what the query returns
 interface Venue {
   id: string;
   name: string;
+  address?: string | null;
+  city?: string | null;
   latitude: number;
   longitude: number;
-  type?: string;
+  type: string;
+  description?: string | null;
+  pet_policy_summary?: string | null;
+  allows_off_leash?: boolean | null;
+  has_outdoor_seating_for_pets?: boolean | null;
+  water_bowls_provided?: boolean | null;
+  opening_hours?: any | null;
 }
-
-// Mock venues for initial display - this will be replaced by API data
-const mockVenues: Venue[] = [
-  { id: '1', name: 'Central Park Cafe', latitude: 35.6895, longitude: 139.6917, type: 'cafe' },
-  { id: '2', name: 'Shibuya Dog Park', latitude: 35.6580, longitude: 139.7016, type: 'park' },
-  { id: '3', name: 'Yoyogi Pet Store', latitude: 35.6700, longitude: 139.6900, type: 'store' },
-  { id: '4', name: 'Another Cafe', latitude: 35.7000, longitude: 139.7500, type: 'cafe' },
-];
-
 
 const MapPage = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterType, setFilterType] = useState('');
-  // const [venues, setVenues] = useState<Venue[]>(mockVenues); // Later from API
 
-  // In a real app, you'd fetch venues based on searchTerm and filterType
-  // For now, we'll just pass all mock venues to the map.
-  // Or, a simple client-side filter for demo:
-  const filteredVenues = mockVenues.filter(venue => {
-    const nameMatch = venue.name.toLowerCase().includes(searchTerm.toLowerCase());
-    const typeMatch = filterType ? venue.type === filterType : true;
-    return nameMatch && typeMatch;
+  // Variables for the GraphQL query
+  const [queryVariables, setQueryVariables] = useState({
+    filterByName: '',
+    filterByType: '',
   });
 
+  const { loading, error, data, refetch } = useQuery(SEARCH_VENUES_QUERY, {
+    variables: queryVariables,
+    notifyOnNetworkStatusChange: true, // Useful if you want to show loading states on refetch
+  });
+
+  const venuesToDisplay: Venue[] = data?.searchVenues || [];
+
+  // Handle search term submission (e.g., on button click or debounce)
+  const handleSearch = () => {
+    setQueryVariables({
+      filterByName: searchTerm,
+      filterByType: filterType,
+    });
+    // refetch(); // useQuery typically refetches when variables change, but explicit refetch can be used.
+  };
+
+  // useEffect to refetch when searchTerm or filterType changes (debounced approach would be better for searchTerm)
+  useEffect(() => {
+    // A simple way to trigger refetch when filters change.
+    // For searchTerm, debounce would be better to avoid too many API calls.
+    const handler = setTimeout(() => {
+        setQueryVariables({
+            filterByName: searchTerm,
+            filterByType: filterType,
+        });
+    }, 500); // Debounce search term by 500ms
+
+    return () => {
+        clearTimeout(handler);
+    };
+  }, [searchTerm, filterType]);
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 100px)' /* Adjust height based on your layout */ }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 120px)' /* Adjust height based on your layout */ }}>
       <h2>Map Discovery</h2>
       <p>
-        Find amazing pet-friendly places! (Simplified Phase 1)
+        Find amazing pet-friendly places! (Fetching from backend)
       </p>
 
-      {/* Search and Filter UI Placeholders */}
       <div style={{
         padding: '1rem 0',
         display: 'flex',
-        gap: '1rem', /* Increased gap */
+        gap: '1rem',
         flexWrap: 'wrap',
-        alignItems: 'center', /* Align items vertically */
-        marginBottom: '1rem' /* Space below controls */
+        alignItems: 'center',
+        marginBottom: '1rem'
       }}>
         <input
           type="text"
-          placeholder="Search by name or area..."
+          placeholder="Search by name..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
-          style={{ minWidth: '250px', flexGrow: 1, maxWidth: '400px' }} // Allow growth but also max width
+          style={{ minWidth: '250px', flexGrow: 1, maxWidth: '400px' }}
         />
         <select
           value={filterType}
           onChange={(e) => setFilterType(e.target.value)}
-          style={{ minWidth: '200px' }} // Ensure select has enough width
+          style={{ minWidth: '200px' }}
         >
           <option value="">All Types</option>
-          <option value="cafe">Pet-Friendly Cafes</option>
+          <option value="cafe">Cafes</option>
           <option value="park">Parks</option>
-          <option value="store">Pet Stores</option>
-          {/* Add more filter options as needed */}
+          <option value="store">Stores</option>
+          <option value="restaurant">Restaurants</option>
+          <option value="hotel">Hotels</option>
+          {/* Add more types as defined in your backend/data */}
         </select>
-        {/* Add more filter controls here, e.g., for amenities */}
+        {/* A button to manually trigger search if not using useEffect-based refetching for all changes */}
+        {/* <button onClick={handleSearch} disabled={loading}>Search</button> */}
       </div>
 
-      {/* Map Display Area */}
-      <div style={{ flexGrow: 1, border: '1px solid #ccc', borderRadius: '4px', overflow: 'hidden' }}>
-        <MapDisplay
-          initialCenter={[35.6895, 139.6917]} // Default to Tokyo
-          initialZoom={12}
-          venues={filteredVenues}
-        />
+      {loading && <p>Loading venues...</p>}
+      {error && <p className="error-message">Error fetching venues: {error.message}</p>}
+
+      <div style={{ flexGrow: 1, border: '1px solid var(--current-border-color)', borderRadius: '4px', overflow: 'hidden' }}>
+        {!loading && !error && (
+          <MapDisplay
+            initialCenter={[35.6895, 139.6917]} // Default to Tokyo, or derive from user's location later
+            initialZoom={11} // Adjust zoom level
+            venues={venuesToDisplay}
+          />
+        )}
       </div>
     </div>
   );

--- a/web/src/components/MapDisplayCore.tsx
+++ b/web/src/components/MapDisplayCore.tsx
@@ -25,13 +25,22 @@ import L from 'leaflet'; // Import L for custom icons if needed later
 // });
 
 
-// Venue type placeholder - will eventually come from GraphQL
+// Updated Venue interface to match data from GraphQL query
 interface Venue {
   id: string;
   name: string;
+  address?: string | null;
+  city?: string | null;
   latitude: number;
   longitude: number;
-  type?: string; // e.g., 'cafe', 'park'
+  type: string;
+  description?: string | null;
+  pet_policy_summary?: string | null;
+  allows_off_leash?: boolean | null;
+  has_outdoor_seating_for_pets?: boolean | null;
+  water_bowls_provided?: boolean | null;
+  opening_hours?: any | null; // JSON object
+  // Add other fields from GraphQL query as needed for display
 }
 
 interface MapDisplayCoreProps {
@@ -81,18 +90,34 @@ const MapDisplayCore: React.FC<MapDisplayCoreProps> = ({
       />
       {venues.map(venue => (
         <Marker key={venue.id} position={[venue.latitude, venue.longitude]}>
-          <Popup>
-            <strong>{venue.name}</strong><br />
-            Type: {venue.type || 'N/A'}
-            {/* Add more venue details here */}
+          <Popup minWidth={250}> {/* Set a minWidth for better layout */}
+            <div style={{ fontSize: '1rem' }}> {/* Slightly larger base font for popup */}
+              <h4 style={{ marginTop: 0, marginBottom: '0.5rem', color: 'var(--primary-color)' }}>{venue.name}</h4>
+              <p style={{ margin: '0.25rem 0' }}><strong>Type:</strong> {venue.type}</p>
+              {venue.address && <p style={{ margin: '0.25rem 0' }}><strong>Address:</strong> {venue.address}{venue.city ? `, ${venue.city}` : ''}</p>}
+              {venue.description && <p style={{ margin: '0.25rem 0' }}>{venue.description}</p>}
+              {venue.pet_policy_summary && <p style={{ margin: '0.25rem 0', fontStyle: 'italic' }}>Pet Policy: {venue.pet_policy_summary}</p>}
+
+              <ul style={{ listStyle: 'none', paddingLeft: 0, marginTop: '0.5rem', fontSize: '0.9rem' }}>
+                {venue.allows_off_leash && <li>✔️ Off-leash allowed</li>}
+                {venue.has_outdoor_seating_for_pets && <li>✔️ Outdoor seating for pets</li>}
+                {venue.water_bowls_provided && <li>✔️ Water bowls provided</li>}
+              </ul>
+
+              {/* Placeholder for opening hours - might need a helper to format nicely */}
+              {/* {venue.opening_hours && <p style={{margin: '0.25rem 0', fontSize: '0.85rem'}}>Hours: {JSON.stringify(venue.opening_hours)}</p>} */}
+
+              {/* Add a link to a future venue details page */}
+              {/* <Link href={`/venues/${venue.id}`}>More details</Link> */}
+            </div>
           </Popup>
         </Marker>
       ))}
-      {/* Example of a single marker if no venues passed */}
+      {/* Example of a single marker if no venues passed and not loading */}
       {venues.length === 0 && (
          <Marker position={initialCenter}>
             <Popup>
-                PawsRoam Map Center! <br /> (Default: Tokyo)
+                PawsRoam Map Center! <br /> (No venues found for current filter)
             </Popup>
         </Marker>
       )}


### PR DESCRIPTION
This commit implements dynamic fetching and display of venue data from a PostgreSQL backend for the map feature.

Key changes:

Backend:
- Defined a `venues` table schema in PostgreSQL (`backend/sql/schema.sql`), inspired by the user's comprehensive `businesses` table structure. Includes fields for location, type, description, policies, etc.
- Added sample INSERT statements for the `venues` table.
- Updated the GraphQL `Venue` type to align with the new table structure, including more detailed fields.
- Modified the `searchVenues` resolver to query the PostgreSQL `venues` table, replacing mock data. Implemented basic filtering by name and type.

Frontend:
- Updated the map page (`web/src/app/map/page.tsx`) to use Apollo Client's `useQuery` hook to fetch venue data from the `searchVenues` backend query.
- Replaced mock venue data with data fetched from the backend.
- Connected search and filter UI elements to trigger refetches with updated query variables.
- Enhanced the map marker popups (`web/src/components/MapDisplayCore.tsx`) to display richer venue information (address, description, pet policies) from the fetched data.

Testing:
- Conceptually outlined tests for the new backend resolver logic and frontend data fetching/display components. Actual implementation of these new tests is deferred.

This significantly advances the map functionality by making it data-driven from the backend.