### PR TITLE
feat: Implement backend for Venue Reviews and Ratings

### DIFF
--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -62,10 +62,53 @@ interface DbPet {
     updated_at: Date;
 }
 
+interface DbReview {
+    id: string; // UUID
+    user_id: string; // UUID
+    venue_id: string; // UUID
+    rating: number;
+    comment?: string | null;
+    visit_date?: Date | null;
+    created_at: Date;
+    updated_at: Date;
+}
+
 // Define context type for resolvers
 interface ResolverContext {
   userId?: string | null; // userId will be injected from Apollo Server context
 }
+
+// Utility function to update venue's average rating and review count
+async function updateVenueRating(venueId: string) {
+  if (!pgPool) return; // Should be handled by calling resolver, but good check
+
+  const ratingQuery = `
+    SELECT
+      COALESCE(AVG(rating), 0) as average_rating,
+      COUNT(id) as review_count
+    FROM reviews
+    WHERE venue_id = $1;
+  `;
+  const updateVenueQuery = `
+    UPDATE venues
+    SET average_rating = $1, review_count = $2
+    WHERE id = $3;
+  `;
+  try {
+    const ratingResult = await pgPool.query(ratingQuery, [venueId]);
+    const { average_rating, review_count } = ratingResult.rows[0];
+
+    // Ensure average_rating is formatted to 2 decimal places if it's a number
+    const formattedAvgRating = parseFloat(average_rating).toFixed(2);
+
+    await pgPool.query(updateVenueQuery, [formattedAvgRating, review_count, venueId]);
+    console.log(`Updated venue ${venueId} with avg_rating: ${formattedAvgRating}, review_count: ${review_count}`);
+  } catch (error) {
+    console.error(`Failed to update venue rating for ${venueId}:`, error);
+    // Decide if this error should propagate or just be logged
+  }
+}
+
 
 interface Resolvers {
   Query: {
@@ -73,6 +116,10 @@ interface Resolvers {
   };
   Mutation?: {
     [key: string]: (parent: any, args: any, context: ResolverContext, info: any) => any;
+  };
+  Review?: { // Field resolvers for Review type
+    user: (parent: DbReview, args: any, context: ResolverContext, info: any) => any;
+    venue: (parent: DbReview, args: any, context: ResolverContext, info: any) => any;
   };
   // Add other types like Pet if they have field resolvers
   // Pet?: {
@@ -107,6 +154,53 @@ export const resolvers: Resolvers = {
       } catch (dbError: any) {
         console.error("Error fetching pets:", dbError);
         throw new GraphQLError('Failed to fetch pets.', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR', originalError: dbError.message },
+        });
+      }
+    },
+    getReviewsForVenue: async (_parent: any, { venueId }: { venueId: string }, context: ResolverContext) => {
+      if (!pgPool) {
+        throw new GraphQLError('Database not configured', { extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+      }
+      try {
+        const result = await pgPool.query<DbReview>(
+          'SELECT * FROM reviews WHERE venue_id = $1 ORDER BY created_at DESC',
+          [venueId]
+        );
+        return result.rows.map(review => ({
+          ...review,
+          visit_date: review.visit_date ? review.visit_date.toISOString().split('T')[0] : null,
+          created_at: review.created_at.toISOString(),
+          updated_at: review.updated_at.toISOString(),
+        }));
+      } catch (dbError: any) {
+        console.error(`Error fetching reviews for venue ${venueId}:`, dbError);
+        throw new GraphQLError('Failed to fetch reviews.', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR', originalError: dbError.message },
+        });
+      }
+    },
+    myReviews: async (_parent: any, _args: any, context: ResolverContext) => {
+      if (!context.userId) {
+        throw new GraphQLError('User is not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      if (!pgPool) {
+        throw new GraphQLError('Database not configured', { extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+      }
+      try {
+        const result = await pgPool.query<DbReview>(
+          'SELECT * FROM reviews WHERE user_id = $1 ORDER BY created_at DESC',
+          [context.userId]
+        );
+        return result.rows.map(review => ({
+          ...review,
+          visit_date: review.visit_date ? review.visit_date.toISOString().split('T')[0] : null,
+          created_at: review.created_at.toISOString(),
+          updated_at: review.updated_at.toISOString(),
+        }));
+      } catch (dbError: any) {
+        console.error('Error fetching user reviews:', dbError);
+        throw new GraphQLError('Failed to fetch your reviews.', {
           extensions: { code: 'INTERNAL_SERVER_ERROR', originalError: dbError.message },
         });
       }
@@ -355,4 +449,232 @@ export const resolvers: Resolvers = {
       }
     },
   },
+  Mutation: {
+    // ... (existing user and pet mutations) ...
+    registerUser: async (_: any, { email, password, name }: { email: string, password: string, name?: string }, context: ResolverContext) => {
+      // ... (implementation from previous step)
+      if (!pgPool) { throw new GraphQLError('DB error'); }
+      const existingUserResult = await pgPool.query<DbUser>('SELECT * FROM users WHERE email = $1', [email]);
+      if (existingUserResult.rows.length > 0) {
+        throw new GraphQLError('Email already in use', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+      const passwordHash = await hashPassword(password);
+      const insertQuery = 'INSERT INTO users (email, name, password_hash) VALUES ($1, $2, $3) RETURNING id, email, name';
+      const values = [email, name || null, passwordHash];
+      const newUserResult = await pgPool.query<DbUser>(insertQuery, values);
+      const newUser = newUserResult.rows[0];
+      const token = generateToken({ id: newUser.id, email: newUser.email });
+      return { token, user: { id: newUser.id, email: newUser.email, name: newUser.name || undefined } };
+    },
+    loginUser: async (_: any, { email, password }: { email: string, password: string }, context: ResolverContext) => {
+      // ... (implementation from previous step)
+      if (!pgPool) { throw new GraphQLError('DB error'); }
+      const result = await pgPool.query<DbUser>('SELECT * FROM users WHERE email = $1', [email]);
+      const user = result.rows[0];
+      if (!user) { throw new GraphQLError('Invalid credentials', { extensions: { code: 'UNAUTHENTICATED' } }); }
+      const isValidPassword = await comparePassword(password, user.password_hash);
+      if (!isValidPassword) { throw new GraphQLError('Invalid credentials', { extensions: { code: 'UNAUTHENTICATED' } }); }
+      const token = generateToken({ id: user.id, email: user.email });
+      return { token, user: { id: user.id, email: user.email, name: user.name || undefined } };
+    },
+    createPet: async (_parent: any, { input }: { input: any }, context: ResolverContext) => {
+      // ... (implementation from previous step)
+      if (!context.userId) { throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } }); }
+      if (!pgPool) { throw new GraphQLError('DB error'); }
+      const { name, species, breed, birthdate, avatar_url, notes } = input;
+      const query = `INSERT INTO pets (user_id, name, species, breed, birthdate, avatar_url, notes) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;`;
+      const values = [context.userId, name, species, breed, birthdate, avatar_url, notes];
+      const result = await pgPool.query<DbPet>(query, values);
+      const newPet = result.rows[0];
+      return { ...newPet, birthdate: newPet.birthdate ? newPet.birthdate.toISOString().split('T')[0] : null, created_at: newPet.created_at.toISOString(),updated_at: newPet.updated_at.toISOString() };
+    },
+    updatePet: async (_parent: any, { id, input }: { id: string, input: any }, context: ResolverContext) => {
+      // ... (implementation from previous step)
+      if (!context.userId) { throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } }); }
+      if (!pgPool) { throw new GraphQLError('DB error'); }
+      const { name, species, breed, birthdate, avatar_url, notes } = input;
+      const existingPetResult = await pgPool.query<DbPet>('SELECT user_id FROM pets WHERE id = $1', [id]);
+      if (existingPetResult.rows.length === 0) { throw new GraphQLError('Pet not found', { extensions: { code: 'NOT_FOUND' } }); }
+      if (existingPetResult.rows[0].user_id !== context.userId) { throw new GraphQLError('Forbidden', { extensions: { code: 'FORBIDDEN' } }); }
+      const setClauses: string[] = []; const values: any[] = []; let valueCount = 1;
+      if (name !== undefined) { setClauses.push(`name = $${valueCount++}`); values.push(name); }
+      if (species !== undefined) { setClauses.push(`species = $${valueCount++}`); values.push(species); }
+      if (breed !== undefined) { setClauses.push(`breed = $${valueCount++}`); values.push(breed); }
+      if (birthdate !== undefined) { setClauses.push(`birthdate = $${valueCount++}`); values.push(birthdate); }
+      if (avatar_url !== undefined) { setClauses.push(`avatar_url = $${valueCount++}`); values.push(avatar_url); }
+      if (notes !== undefined) { setClauses.push(`notes = $${valueCount++}`); values.push(notes); }
+      if (setClauses.length === 0) { throw new GraphQLError('No update fields', { extensions: { code: 'BAD_USER_INPUT' } }); }
+      setClauses.push(`updated_at = CURRENT_TIMESTAMP`);
+      const query = `UPDATE pets SET ${setClauses.join(', ')} WHERE id = $${valueCount++} AND user_id = $${valueCount++} RETURNING *;`;
+      values.push(id, context.userId);
+      const result = await pgPool.query<DbPet>(query, values);
+      const updatedPet = result.rows[0];
+      return { ...updatedPet, birthdate: updatedPet.birthdate ? updatedPet.birthdate.toISOString().split('T')[0] : null, created_at: updatedPet.created_at.toISOString(),updated_at: updatedPet.updated_at.toISOString() };
+    },
+    deletePet: async (_parent: any, { id }: { id: string }, context: ResolverContext) => {
+      // ... (implementation from previous step)
+      if (!context.userId) { throw new GraphQLError('Not authenticated', { extensions: { code: 'UNAUTHENTICATED' } }); }
+      if (!pgPool) { throw new GraphQLError('DB error'); }
+      const query = 'DELETE FROM pets WHERE id = $1 AND user_id = $2 RETURNING id;';
+      const result = await pgPool.query(query, [id, context.userId]);
+      return result.rowCount === 1;
+    },
+
+    addReview: async (_parent: any, { input }: { input: any }, context: ResolverContext) => {
+      if (!context.userId) {
+        throw new GraphQLError('User is not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      if (!pgPool) {
+        throw new GraphQLError('Database not configured', { extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+      }
+      const { venueId, rating, comment, visit_date } = input;
+      // Input validation for rating
+      if (rating < 1 || rating > 5) {
+        throw new GraphQLError('Rating must be between 1 and 5', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+
+      const query = `
+        INSERT INTO reviews (user_id, venue_id, rating, comment, visit_date)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING *;
+      `;
+      const values = [context.userId, venueId, rating, comment, visit_date];
+      try {
+        const result = await pgPool.query<DbReview>(query, values);
+        const newReview = result.rows[0];
+
+        await updateVenueRating(venueId); // Update venue's average rating
+
+        return { // Map to GraphQL Review type
+          ...newReview,
+          visit_date: newReview.visit_date ? newReview.visit_date.toISOString().split('T')[0] : null,
+          created_at: newReview.created_at.toISOString(),
+          updated_at: newReview.updated_at.toISOString(),
+        };
+      } catch (dbError: any) {
+        console.error("Error adding review:", dbError);
+        if (dbError.constraint === 'uq_user_venue_review') {
+            throw new GraphQLError('You have already reviewed this venue.', { extensions: { code: 'BAD_USER_INPUT' } });
+        }
+        throw new GraphQLError('Failed to add review.', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR', originalError: dbError.message },
+        });
+      }
+    },
+
+    updateReview: async (_parent: any, { reviewId, input }: { reviewId: string, input: any }, context: ResolverContext) => {
+      if (!context.userId) {
+        throw new GraphQLError('User is not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      if (!pgPool) {
+        throw new GraphQLError('Database not configured', { extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+      }
+
+      // Check if review exists and belongs to the user
+      const existingReviewResult = await pgPool.query<DbReview>('SELECT user_id, venue_id FROM reviews WHERE id = $1', [reviewId]);
+      if (existingReviewResult.rows.length === 0) {
+        throw new GraphQLError('Review not found', { extensions: { code: 'NOT_FOUND' } });
+      }
+      const existingReview = existingReviewResult.rows[0];
+      if (existingReview.user_id !== context.userId) {
+        throw new GraphQLError('User not authorized to update this review', { extensions: { code: 'FORBIDDEN' } });
+      }
+
+      const { rating, comment, visit_date } = input;
+      if (rating !== undefined && (rating < 1 || rating > 5)) {
+        throw new GraphQLError('Rating must be between 1 and 5', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+
+      const setClauses: string[] = [];
+      const values: any[] = [];
+      let valueCount = 1;
+
+      if (rating !== undefined) { setClauses.push(`rating = $${valueCount++}`); values.push(rating); }
+      if (comment !== undefined) { setClauses.push(`comment = $${valueCount++}`); values.push(comment); }
+      if (visit_date !== undefined) { setClauses.push(`visit_date = $${valueCount++}`); values.push(visit_date); }
+
+      if (setClauses.length === 0) {
+        throw new GraphQLError('No update fields provided', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+      setClauses.push(`updated_at = CURRENT_TIMESTAMP`);
+
+      const query = `
+        UPDATE reviews SET ${setClauses.join(', ')}
+        WHERE id = $${valueCount++} AND user_id = $${valueCount++}
+        RETURNING *;
+      `;
+      values.push(reviewId, context.userId);
+
+      try {
+        const result = await pgPool.query<DbReview>(query, values);
+        const updatedReview = result.rows[0];
+
+        await updateVenueRating(existingReview.venue_id); // Update venue's average rating
+
+        return {
+          ...updatedReview,
+          visit_date: updatedReview.visit_date ? updatedReview.visit_date.toISOString().split('T')[0] : null,
+          created_at: updatedReview.created_at.toISOString(),
+          updated_at: updatedReview.updated_at.toISOString(),
+        };
+      } catch (dbError: any) {
+        console.error("Error updating review:", dbError);
+        throw new GraphQLError('Failed to update review.', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR', originalError: dbError.message },
+        });
+      }
+    },
+
+    deleteReview: async (_parent: any, { reviewId }: { reviewId: string }, context: ResolverContext) => {
+      if (!context.userId) {
+        throw new GraphQLError('User is not authenticated', { extensions: { code: 'UNAUTHENTICATED' } });
+      }
+      if (!pgPool) {
+        throw new GraphQLError('Database not configured', { extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+      }
+
+      // Get venue_id before deleting for rating update
+      const reviewDataResult = await pgPool.query<{ venue_id: string }>('SELECT venue_id FROM reviews WHERE id = $1 AND user_id = $2', [reviewId, context.userId]);
+      if (reviewDataResult.rows.length === 0) {
+          throw new GraphQLError('Review not found or user not authorized', { extensions: { code: 'NOT_FOUND' } });
+      }
+      const { venue_id } = reviewDataResult.rows[0];
+
+      const query = 'DELETE FROM reviews WHERE id = $1 AND user_id = $2 RETURNING id;';
+      try {
+        const result = await pgPool.query(query, [reviewId, context.userId]);
+        if (result.rowCount === 1) {
+            await updateVenueRating(venue_id); // Update venue's average rating
+            return true;
+        }
+        return false;
+      } catch (dbError: any) {
+        console.error("Error deleting review:", dbError);
+        throw new GraphQLError('Failed to delete review.', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR', originalError: dbError.message },
+        });
+      }
+    },
+  },
+  Review: {
+    user: async (parent: DbReview, _args: any, _context: ResolverContext) => {
+      if (!pgPool) throw new GraphQLError('Database not configured');
+      const result = await pgPool.query<DbUser>('SELECT id, name, email FROM users WHERE id = $1', [parent.user_id]);
+      return result.rows[0] ? { ...result.rows[0] } : null;
+    },
+    venue: async (parent: DbReview, _args: any, _context: ResolverContext) => {
+      if (!pgPool) throw new GraphQLError('Database not configured');
+      const result = await pgPool.query<DbVenue>('SELECT * FROM venues WHERE id = $1', [parent.venue_id]);
+      // Basic mapping, ensure all fields match GraphQL Venue type or map them
+      const venue = result.rows[0];
+      return venue ? {
+        ...venue,
+        latitude: parseFloat(venue.latitude as any),
+        longitude: parseFloat(venue.longitude as any),
+        weight_limit_kg: venue.weight_limit_kg ? parseFloat(venue.weight_limit_kg as any) : null,
+        created_at: venue.created_at.toISOString(),
+        updated_at: venue.updated_at.toISOString(),
+       } : null;
+    }
+  }
 };

--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -18,6 +18,8 @@ type Query {
   testGemini(prompt: String!): String # Test query for Gemini API
   searchVenues(filterByName: String, filterByType: String): [Venue!] # Query for venues
   myPets: [Pet!] # Query to get pets for the authenticated user
+  getReviewsForVenue(venueId: ID!): [Review!]
+  myReviews: [Review!]
 }
 
 type Mutation {
@@ -27,6 +29,34 @@ type Mutation {
   createPet(input: CreatePetInput!): Pet!
   updatePet(id: ID!, input: UpdatePetInput!): Pet
   deletePet(id: ID!): Boolean
+
+  addReview(input: CreateReviewInput!): Review!
+  updateReview(reviewId: ID!, input: UpdateReviewInput!): Review
+  deleteReview(reviewId: ID!): Boolean
+}
+
+type Review {
+  id: ID!
+  rating: Int!
+  comment: String
+  visit_date: String # e.g., "YYYY-MM-DD"
+  user: User! # The user who wrote the review
+  venue: Venue! # The venue being reviewed
+  created_at: String! # ISO8601 String
+  updated_at: String! # ISO8601 String
+}
+
+input CreateReviewInput {
+  venueId: ID!
+  rating: Int! # e.g., 1-5
+  comment: String
+  visit_date: String # e.g., "YYYY-MM-DD"
+}
+
+input UpdateReviewInput {
+  rating: Int
+  comment: String
+  visit_date: String # e.g., "YYYY-MM-DD"
 }
 
 type Pet {
@@ -96,10 +126,11 @@ type Venue {
   status: String # e.g., 'active', 'pending_approval'
   google_place_id: String
 
+  average_rating: Float # From venues table
+  review_count: Int   # From venues table
+
   created_at: String # Typically represented as ISO8601 String
   updated_at: String # Typically represented as ISO8601 String
-
-  # Future computed fields can be added here, e.g., averageRating
 }
 
 # Input type for filtering venues (optional for Phase 1 simple filter)


### PR DESCRIPTION
This commit introduces the backend infrastructure for venue reviews and ratings.

Key changes:

- Database (PostgreSQL - `backend/sql/schema.sql`):
  - Added a `reviews` table to store user reviews, including `user_id`, `venue_id`, `rating`, `comment`, `visit_date`, and timestamps. Includes a unique constraint for (user_id, venue_id).
  - Updated the `venues` table to include `average_rating` (DECIMAL) and `review_count` (INTEGER) columns to store aggregated review data.

- GraphQL Schema (`backend/src/graphql/schema.graphql`):
  - Defined the `Review` GraphQL type with fields for review content and resolved `user` and `venue` objects.
  - Added input types `CreateReviewInput` and `UpdateReviewInput`.
  - Introduced mutations: `addReview`, `updateReview`, `deleteReview`.
  - Introduced queries: `getReviewsForVenue` (fetches reviews for a specific venue) and `myReviews` (fetches reviews by the authenticated user).
  - Updated the `Venue` GraphQL type to include `average_rating` and `review_count`.

- Resolvers (`backend/src/graphql/resolvers.ts`):
  - Implemented resolvers for all new review-related queries and mutations.
  - `addReview`, `updateReview`, `deleteReview` operations include logic to ensure user authentication and authorization (users can only manage their own reviews).
  - Created and integrated an `updateVenueRating` utility function that recalculates and updates the `average_rating` and `review_count` on the `venues` table whenever a review is added, modified, or deleted.
  - Implemented field resolvers for `Review.user` and `Review.venue` to fetch associated user and venue data.

This provides the necessary backend support for the upcoming frontend implementation of venue reviews and ratings.