### PR TITLE
feat: Implement Admin Role Foundations and User Management Backend

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -13,12 +13,16 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(255) UNIQUE NOT NULL,
     name VARCHAR(255),
     password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'user', -- Roles: 'user', 'admin', 'business_owner', 'paws_safer'
+    status VARCHAR(50) NOT NULL DEFAULT 'active', -- Statuses: 'active', 'pending_verification', 'suspended'
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Optional: Index on email for faster lookups
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role); -- Index for role
+CREATE INDEX IF NOT EXISTS idx_users_status ON users(status); -- Index for status
 
 -- Optional: Trigger to update 'updated_at' timestamp automatically
 CREATE OR REPLACE FUNCTION trigger_set_timestamp()

--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -4,7 +4,11 @@ type User {
   id: ID!
   email: String!
   name: String
-  # Add other user fields as needed, e.g., createdAt
+  role: String!
+  status: String!
+  created_at: String # ISO8601 String for consistency
+  updated_at: String # ISO8601 String for consistency
+  # Add other user fields as needed
 }
 
 type AuthPayload {


### PR DESCRIPTION
This commit establishes the backend infrastructure for an 'admin' user role and basic admin-level user management capabilities.

Key changes:

Backend:
- Database (`backend/sql/schema.sql`):
  - Added `role` (VARCHAR, default 'user') and `status` (VARCHAR, default 'active') columns to the `users` table.
  - Added indexes on these new columns.

- GraphQL Schema (`backend/src/graphql/schema.graphql`):
  - Updated the `User` type to include `role` and `status` fields (plus `created_at`, `updated_at`).
  - Defined new admin-specific queries and mutations:
    - Query: `adminGetAllUsers: [User!]`
    - Mutation: `adminUpdateUser(userId: ID!, role: String, status: String): User`

- Resolvers & Authorization (`backend/src/graphql/resolvers.ts`, `backend/src/utils/auth.ts`):
  - Updated `DbUser` interface to include `role` and `status`.
  - Modified `registerUser` resolver to set default 'user' role and 'active' status.
  - Modified `loginUser` resolver to fetch and return user's role and status, and to prevent login for 'suspended' users.
  - Implemented an `ensureAdmin(context)` helper function in `auth.ts` to verify if the authenticated user has the 'admin' role by checking the database. This function throws appropriate GraphQLErrors if checks fail.
  - Implemented resolvers for `adminGetAllUsers` and `adminUpdateUser`, both protected by the `ensureAdmin` helper.

- Documentation:
  - Added instructions to `backend/README.md` on how to manually set a user's role to 'admin' in the database for initial setup.

This work provides the necessary backend support for admin-only operations and user management, paving the way for building out the admin interface on the frontend.