### PR TITLE
feat: Implement Frontend Admin Interface for User Management

### DIFF
--- a/web/src/app/admin/AdminLayout.module.css
+++ b/web/src/app/admin/AdminLayout.module.css
@@ -1,0 +1,32 @@
+.adminNavLink {
+  display: block;
+  padding: 0.75rem 0.5rem; /* Added some horizontal padding */
+  color: var(--primary-color);
+  text-decoration: none;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px; /* Added border-radius */
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.adminNavLink:hover {
+  background-color: var(--primary-light);
+  color: var(--primary-dark);
+  text-decoration: none; /* Ensure no underline on hover if not desired for these links */
+}
+
+.adminPageTitle {
+  margin-bottom: 1.5rem;
+  color: var(--primary-dark);
+  border-bottom: 1px solid var(--current-border-color);
+  padding-bottom: 0.5rem;
+}
+
+.adminSection {
+  background-color: var(--current-surface);
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  margin-bottom: 1.5rem;
+  border: 1px solid var(--current-border-color);
+}

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { ReactNode } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import styles from './AdminLayout.module.css'; // Import the CSS module
+
+// Basic styles for the admin layout (some can remain, others can move to module)
+const adminLayoutContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  minHeight: 'calc(100vh - 60px)', // Assuming main layout header is approx 60px (from main Layout.tsx)
+};
+
+const adminSidebarStyle: React.CSSProperties = {
+  width: '220px',
+  backgroundColor: 'var(--current-surface)',
+  padding: '1.5rem',
+  borderRight: '1px solid var(--current-border-color)',
+  flexShrink: 0, // Prevent sidebar from shrinking
+};
+
+const adminContentStyle: React.CSSProperties = {
+  flexGrow: 1,
+  padding: '1.5rem',
+  backgroundColor: 'var(--current-background)',
+  overflowY: 'auto', // Allow content to scroll if it's too long
+};
+
+
+const AdminLayout = ({ children }: { children: ReactNode }) => {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+
+  if (authLoading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 'calc(100vh - 60px)' }}>
+        <p>Loading admin section...</p>
+      </div>
+    );
+  }
+
+  if (!user || user.role !== 'admin') {
+    // Option 1: Redirect (uncomment to use)
+    // React.useEffect(() => {
+    //   router.push('/');
+    // }, [router]);
+    // return (
+    //   <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 'calc(100vh - 60px)' }}>
+    //     <p>Redirecting...</p>
+    //   </div>
+    // );
+
+    // Option 2: Show Access Denied message
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center' }}>
+        <h2>Access Denied</h2>
+        <p>You do not have permission to view this page.</p>
+        <Link href="/">Go to Homepage</Link>
+      </div>
+    );
+  }
+
+  // If user is admin, render the admin layout
+  return (
+    <div style={adminLayoutContainerStyle}>
+      <aside style={adminSidebarStyle}>
+        <h3 style={{ color: 'var(--primary-dark)', marginBottom: '1.5rem', borderBottom: '1px solid var(--current-border-color)', paddingBottom: '0.5rem' }}>Admin Menu</h3>
+        <nav>
+          <Link href="/admin" className={styles.adminNavLink}>Dashboard</Link>
+          <Link href="/admin/users" className={styles.adminNavLink}>Manage Users</Link>
+          {/* Add more admin links here as features are added */}
+          {/* e.g., <Link href="/admin/venues" className={styles.adminNavLink}>Manage Venues</Link> */}
+          {/* e.g., <Link href="/admin/reviews" className={styles.adminNavLink}>Manage Reviews</Link> */}
+        </nav>
+      </aside>
+      <main style={adminContentStyle}>
+        {children}
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,53 @@
+'use client'; // Good practice for pages that might use hooks or interactivity, though this one is simple
+
+import React from 'react';
+import Link from 'next/link';
+import adminStyles from './AdminLayout.module.css'; // Import shared admin styles
+
+// Re-using cardStyle from AdminLayout.module.css or define locally if preferred
+// For this example, I'll assume adminStyles.adminSection can be used for card-like appearance.
+
+const linkStyle: React.CSSProperties = { // Keep this for specific link styling if needed
+  textDecoration: 'none',
+  color: 'var(--primary-color)',
+  fontWeight: '500',
+};
+
+const AdminDashboardPage = () => {
+  return (
+    <div>
+      <h2 className={adminStyles.adminPageTitle}>Admin Dashboard</h2>
+      <p style={{ marginBottom: '2rem', fontSize: '1.1rem' }}>
+        Welcome to the PawsRoam Admin Area. From here, you can manage various aspects of the application.
+      </p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.5rem' }}>
+        <div className={adminStyles.adminSection}> {/* Using adminSection for card style */}
+          <h3 style={{ marginTop: 0, marginBottom: '1rem' }}>User Management</h3>
+          <p style={{ marginBottom: '1rem', color: 'var(--text-color-muted)', fontSize: '0.9rem' }}>
+            View, edit roles, and manage user statuses.
+          </p>
+          <Link href="/admin/users" style={linkStyle}>Go to Manage Users &rarr;</Link>
+        </div>
+
+        <div className={adminStyles.adminSection}>
+          <h3 style={{ marginTop: 0, marginBottom: '1rem' }}>Venue Management</h3>
+          <p style={{ marginBottom: '1rem', color: 'var(--text-color-muted)', fontSize: '0.9rem' }}>
+            Approve, edit, or manage venue listings.
+          </p>
+          <span style={{ color: 'var(--text-color-muted)' }}>(Coming Soon)</span>
+        </div>
+
+        <div className={adminStyles.adminSection}>
+          <h3 style={{ marginTop: 0, marginBottom: '1rem' }}>Review Moderation</h3>
+          <p style={{ marginBottom: '1rem', color: 'var(--text-color-muted)', fontSize: '0.9rem' }}>
+            View and manage user-submitted reviews.
+          </p>
+          <span style={{ color: 'var(--text-color-muted)' }}>(Coming Soon)</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboardPage;

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+'use client';
+
+import React, { useState, ChangeEvent } from 'react';
+import { gql, useQuery, useMutation } from '@apollo/client';
+// import Link from 'next/link'; // Not used in this version
+import adminStyles from '../AdminLayout.module.css'; // Import shared admin styles
+
+// Define the GraphQL query for fetching users
+const ADMIN_GET_ALL_USERS_QUERY = gql`
+  query AdminGetAllUsers {
+    adminGetAllUsers {
+      id
+      email
+      name
+      role
+      status
+      created_at
+      updated_at
+    }
+  }
+`;
+
+// Define the GraphQL mutation for updating user
+const ADMIN_UPDATE_USER_MUTATION = gql`
+  mutation AdminUpdateUser($userId: ID!, $role: String, $status: String) {
+    adminUpdateUser(userId: $userId, role: $role, status: $status) {
+      id
+      role
+      status
+      # Potentially refetch other fields if they could change due to role/status, or rely on cache update
+    }
+  }
+`;
+
+// Define available roles and statuses for dropdowns
+const AVAILABLE_ROLES = ['user', 'admin', 'business_owner', 'paws_safer']; // Add more as defined in backend
+const AVAILABLE_STATUSES = ['active', 'suspended', 'pending_verification']; // Add more as defined
+
+// Define the expected User type from the query
+interface User {
+  id: string;
+  email: string;
+  name?: string | null;
+  role: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// Basic styles for the table
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  marginTop: '1.5rem',
+};
+
+const thStyle: React.CSSProperties = {
+  borderBottom: '2px solid var(--current-border-color)',
+  padding: '0.75rem 1rem',
+  textAlign: 'left',
+  backgroundColor: 'var(--current-surface)', // Light background for header
+  color: 'var(--primary-dark)',
+  fontWeight: '600',
+};
+
+const tdStyle: React.CSSProperties = {
+  borderBottom: '1px solid var(--current-border-color)',
+  padding: '0.75rem 1rem',
+  verticalAlign: 'middle', // Changed to middle for form elements
+};
+
+// Component for each user row to manage its own state for role/status editing
+interface UserRowProps {
+  user: User;
+  onUpdateSuccess: () => void; // Callback to refetch user list or notify parent
+}
+
+const UserRow: React.FC<UserRowProps> = ({ user, onUpdateSuccess }) => {
+  const [selectedRole, setSelectedRole] = useState(user.role);
+  const [selectedStatus, setSelectedStatus] = useState(user.status);
+  const [updateMessage, setUpdateMessage] = useState<string | null>(null);
+
+  const [adminUpdateUser, { loading: updateLoading, error: updateError }] = useMutation(ADMIN_UPDATE_USER_MUTATION, {
+    onCompleted: () => {
+      setUpdateMessage('User updated successfully!');
+      onUpdateSuccess(); // Trigger refetch or cache update in parent
+      setTimeout(() => setUpdateMessage(null), 3000); // Clear message after 3s
+    },
+    onError: (err) => {
+      setUpdateMessage(`Error: ${err.message}`);
+      // Optionally revert selectedRole/Status if desired, or let user retry
+      setTimeout(() => setUpdateMessage(null), 5000);
+    }
+  });
+
+  const handleUpdate = () => {
+    const variables: { userId: string; role?: string; status?: string } = { userId: user.id };
+    let changesMade = false;
+
+    if (selectedRole !== user.role) {
+      variables.role = selectedRole;
+      changesMade = true;
+    }
+    if (selectedStatus !== user.status) {
+      variables.status = selectedStatus;
+      changesMade = true;
+    }
+
+    if (changesMade) {
+      adminUpdateUser({ variables });
+    } else {
+      setUpdateMessage("No changes to update.");
+      setTimeout(() => setUpdateMessage(null), 3000);
+    }
+  };
+
+  return (
+    <tr key={user.id}>
+      <td style={tdStyle} title={user.id}>{user.id.substring(0, 8)}...</td>
+      <td style={tdStyle}>{user.email}</td>
+      <td style={tdStyle}>{user.name || 'N/A'}</td>
+      <td style={tdStyle}>
+        <select
+          value={selectedRole}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedRole(e.target.value)}
+          disabled={updateLoading}
+          style={{ width: '100%', minWidth: '120px' }}
+        >
+          {AVAILABLE_ROLES.map(role => <option key={role} value={role}>{role}</option>)}
+        </select>
+      </td>
+      <td style={tdStyle}>
+        <select
+          value={selectedStatus}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedStatus(e.target.value)}
+          disabled={updateLoading}
+          style={{ width: '100%', minWidth: '120px' }}
+        >
+          {AVAILABLE_STATUSES.map(status => <option key={status} value={status}>{status}</option>)}
+        </select>
+      </td>
+      <td style={tdStyle}>{new Date(user.created_at).toLocaleDateString()}</td>
+      <td style={tdStyle}>{new Date(user.updated_at).toLocaleDateString()}</td>
+      <td style={tdStyle}>
+        <button onClick={handleUpdate} disabled={updateLoading} className="button-style" style={{padding: '0.5rem 1rem', fontSize: '0.9rem'}}>
+          {updateLoading ? 'Updating...' : 'Update'}
+        </button>
+        {updateMessage && <p style={{ fontSize: '0.8rem', color: updateError ? 'red' : 'green', marginTop: '0.5rem' }}>{updateMessage}</p>}
+      </td>
+    </tr>
+  );
+};
+
+
+const ManageUsersPage = () => {
+  const { loading, error, data, refetch: refetchUsers } = useQuery(ADMIN_GET_ALL_USERS_QUERY);
+
+  if (loading) return <p>Loading users...</p>;
+  if (error) return <p className="error-message">Error loading users: {error.message}</p>;
+
+  const users: User[] = data?.adminGetAllUsers || [];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}> {/* Removed marginBottom from here */}
+        <h2 className={adminStyles.adminPageTitle}>Manage Users</h2>
+        {/* Optional: Add button for creating users if that's a feature */}
+      </div>
+
+      {users.length === 0 ? (
+        <p>No users found.</p>
+      ) : (
+        <div style={{ overflowX: 'auto' }}> {/* For responsive table */}
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={thStyle}>ID</th>
+                <th style={thStyle}>Email</th>
+                <th style={thStyle}>Name</th>
+                <th style={thStyle}>Role</th>
+                <th style={thStyle}>Status</th>
+                <th style={thStyle}>Created At</th>
+                <th style={thStyle}>Updated At</th>
+                <th style={thStyle}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <UserRow key={user.id} user={user} onUpdateSuccess={refetchUsers} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ManageUsersPage;


### PR DESCRIPTION
This commit introduces the frontend components and logic for a basic admin interface, focusing on user management.

Key Frontend Changes (web/):
- Admin Layout & Route Guard (`app/admin/layout.tsx`):
  - Created a client-side layout that checks if the authenticated user has the 'admin' role.
  - If not an admin, it displays an "Access Denied" message.
  - If admin, it renders a sidebar with admin navigation (Dashboard, Manage Users) and the main content area.
  - Includes basic styling for the admin area using CSS variables and a new CSS module (`AdminLayout.module.css`).

- Admin Dashboard Page (`app/admin/page.tsx`):
  - Created a simple dashboard page as the entry point for the admin section.
  - Displays a welcome message and styled cards linking to "Manage Users" and placeholders for future admin functionalities.
  - Uses shared admin styles for page title and section cards.

- Manage Users Page (`app/admin/users/page.tsx`):
  - Fetches all users using the `adminGetAllUsers` GraphQL query via Apollo Client's `useQuery` hook.
  - Displays users in an HTML table with relevant details (ID, email, name, role, status, timestamps).
  - Implemented a `UserRow` component for each user, allowing admins to:
    - Change a user's role via a dropdown.
    - Change a user's status via a dropdown.
    - Update these details using the `adminUpdateUser` GraphQL mutation.
  - Handles loading/error states for data fetching and provides user feedback for update operations.
  - Includes basic styling for the table and form elements within each row.

- Styling:
  - Enhanced `AdminLayout.module.css` for common admin UI elements.
  - Applied styles consistently across new admin pages.

This provides a functional, albeit basic, interface for administrators to view and manage user roles and statuses.