### PR TITLE
feat: Implement User Geolocation on Map Page

### DIFF
--- a/web/src/components/MapDisplay.tsx
+++ b/web/src/components/MapDisplay.tsx
@@ -14,7 +14,8 @@ interface MapDisplayProps {
   initialCenter?: [number, number];
   initialZoom?: number;
   venues?: Venue[];
-  onViewReviews: (venueId: string, venueName: string) => void; // Added prop
+  onViewReviews: (venueId: string, venueName: string) => void;
+  userLocation?: { lat: number; lng: number } | null; // Add userLocation prop
 }
 
 // Dynamically import the MapDisplayCore component with SSR turned off


### PR DESCRIPTION
Frontend:
- Added 'Use My Location' button to the map page (`/map/page.tsx`).
- Implemented logic to request user's current location using `navigator.geolocation.getCurrentPosition()`.
- Handled success and error cases for geolocation, providing user feedback.
- Passed the obtained user location to the `MapDisplayCore` component.
- In `MapDisplayCore.tsx`:
  - Used `useMap` hook and `useEffect` to re-center the map to the user's location when it becomes available or changes, via `map.setView()`.
  - Updated `MapContainer` props to prioritize user's location for initial centering if available.
  - Added an optional marker at the user's current location with a popup.
- Updated `MapDisplayProps` in `MapDisplay.tsx` to include `userLocation`.