### PR TITLE
feat: Implement Backend Geospatial Search for Venues

### DIFF
--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -20,7 +20,13 @@ type Query {
   _empty: String # Placeholder to ensure Query type is valid
   # me: User # Example query to get current user
   testGemini(prompt: String!): String # Test query for Gemini API
-  searchVenues(filterByName: String, filterByType: String): [Venue!] # Query for venues
+  searchVenues(
+    filterByName: String,
+    filterByType: String,
+    latitude: Float,
+    longitude: Float,
+    radiusKm: Float
+  ): [Venue!] # Query for venues, now with optional geo-filtering
   myPets: [Pet!] # Query to get pets for the authenticated user
   getPetById(id: ID!): Pet # Query to get a single pet by its ID, for editing
   getVenueById(id: ID!): Venue # Query to get a single venue by its ID


### PR DESCRIPTION
Backend:
- Updated `searchVenues` GraphQL query in schema.graphql to accept optional `latitude`, `longitude`, and `radiusKm` parameters.
- Modified `searchVenues` resolver in resolvers.ts:
  - If location parameters are provided, calculates distance using Haversine formula in SQL and filters venues within the given radius.
  - Orders results by distance when location is used.
  - Combines geospatial filters with existing name/type filters.
  - Falls back to non-geospatial filtering if location parameters are absent.
- (Unit tests for resolver changes would be added in a full dev cycle).

Frontend:
- Updated `SEARCH_VENUES_QUERY` in `map/page.tsx` to include new geospatial parameters.
- Modified `MapPage.tsx` to set `latitude`, `longitude`, and a default `radiusKm` in query variables when `userLocation` is available.
- Ensured that text/type filter changes preserve the location context in query variables if already set.