### PR TITLE
feat: Enable Shop Owners to Edit & Delete Owned Venues

### DIFF
--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -145,6 +145,7 @@ type Mutation {
 
   # Admin mutations for venue claims
   adminReviewVenueClaim(input: AdminReviewVenueClaimInput!): VenueClaim!
+  shopOwnerDeleteVenue(venueId: ID!): Boolean # New mutation for shop owner to delete their venue
 
   # Pet Alert Mutations
   createPetAlert(input: CreatePetAlertInput!): PetAlert!


### PR DESCRIPTION
Backend:
- Added `shopOwnerDeleteVenue(venueId: ID!): Boolean` mutation to schema.
- Implemented resolver for `shopOwnerDeleteVenue`:
  - Ensures user is 'business_owner' or 'admin'.
  - Verifies venue ownership if user is not admin.
  - Deletes the venue.
- Updated `ShopOwnerUpdateVenueInput` to explicitly exclude status and owner_user_id.
- Ensured `shopOwnerUpdateVenueDetails` and `shopOwnerUpdateVenueImage` resolvers correctly check ownership.
- Added unit tests for `shopOwnerDeleteVenue` and updated tests for update mutations to reflect stricter input/logic for shop owners.

Frontend:
- Finalized "Edit Venue" page for shop owners (`/shop-owner/venues/edit/[venueId]`):
  - `VenueForm` is configured to use `shopOwnerUpdateVenueDetails` mutation.
  - `VenueImageUpload` is configured to use `shopOwnerUpdateVenueImage` mutation.
  - `VenueForm` correctly restricts shop owners from editing `status` and `owner_user_id` fields.
  - Added a "Delete Venue" button and functionality, calling `shopOwnerDeleteVenue` with confirmation.
- Ensured "Edit" links on "My Venues" page point to the correct shop owner edit page.