### PR TITLE
fix: Update netlify.toml with explicit paths for build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,10 @@
 # netlify.toml
 
-# Build settings for the Next.js app.
-# If your Netlify site settings have "Base directory" set to "web/",
-# then the command and publish are relative to that.
-# If "Base directory" is repository root, command should be "cd web && npm run build".
+# Explicit build settings for the Next.js app located in the 'web' subdirectory.
+# This configuration assumes Netlify's build process starts from the repository root.
 [build]
-  command = "npm run build" # Assumes Netlify "Base directory" is set to "web/" in the UI.
-  publish = ".next/"      # Publish directory relative to the "Base directory" ("web/").
+  command = "cd web && npm run build" # Change directory to 'web' then run the build script
+  publish = "web/.next/"             # Publish directory relative to the repository root
 
 # Essential plugin for Next.js on Netlify.
 # This plugin handles most of the Next.js specific configurations,


### PR DESCRIPTION
- Changed build command to `cd web && npm run build` to ensure it runs in the Next.js app's subdirectory.
- Set publish directory to `web/.next/` relative to the repository root.

This makes the Netlify configuration more self-contained and less reliant on UI base directory settings, aiming to resolve previous build failures related to pathing and rule processing.