### PR TITLE
fix: Include npm install in Netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@
 # Explicit build settings for the Next.js app located in the 'web' subdirectory.
 # This configuration assumes Netlify's build process starts from the repository root.
 [build]
-  command = "cd web && npm run build" # Change directory to 'web' then run the build script
-  publish = "web/.next/"             # Publish directory relative to the repository root
+  command = "cd web && npm install && npm run build" # Install deps in web/ then build
+  publish = "web/.next/"                             # Publish directory relative to the repository root
 
 # Essential plugin for Next.js on Netlify.
 # This plugin handles most of the Next.js specific configurations,


### PR DESCRIPTION
- Updated `netlify.toml` build command to `cd web && npm install && npm run build`.
- This ensures that dependencies for the Next.js application within the `web/` subdirectory are installed in the Netlify build environment before attempting to run `next build`.
- This change is intended to resolve the 'next: not found' error during Netlify deployments.