### PR TITLE
fix: Apply Netlify's suggested JSX parenthesizing in my-alerts

### DIFF
--- a/web/src/app/profile/my-alerts/page.tsx
+++ b/web/src/app/profile/my-alerts/page.tsx
@@ -144,7 +144,7 @@ const MyAlertsPageContent: React.FC = () => {
   const alerts = data?.getMyCreatedAlerts || [];
 
   return ( // Added explicit parentheses
-    <div style={pageContainerStyle}>
+    (<div style={pageContainerStyle}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
         <h1 style={{color: 'var(--primary-color)'}}>My Reported Alerts</h1>
         <Link href="/alerts/create" className="button-style primary">
@@ -205,8 +205,8 @@ const MyAlertsPageContent: React.FC = () => {
           </div>
         ))
       )}
-    </div>
-  ); // Added explicit parentheses
+    </div>) // Added explicit parentheses
+  );
 };
 
 const MyAlertsPage = () => {


### PR DESCRIPTION
- Modified the return statement in `web/src/app/profile/my-alerts/page.tsx` to add extra parentheses around the root `div` element, as per the specific suggestion in the Netlify build diagnosis.
- This change targets the 'Unexpected token `div`. Expected jsx identifier' error.